### PR TITLE
Validate share totals in Growth chart

### DIFF
--- a/index/Growth.html
+++ b/index/Growth.html
@@ -73,6 +73,7 @@
       <tbody></tbody>
     </table>
     <button id="addShareholder">Add Shareholder</button>
+    <div id="warning" style="color:red;display:none;"></div>
     <div>
       <label>Growth threshold (£M): <input type="number" id="threshold" value="5" min="0" step="0.1"></label><br>
       <label>Max value (£M): <input type="number" id="maxValue" value="10" min="0" step="0.1"></label>
@@ -118,6 +119,22 @@
                       <td><button data-idx="${idx}" class="delete">X</button></td>`;
         tbody.appendChild(tr);
       });
+    }
+
+    function validateTotals(){
+      const ordTotal = shareholders.reduce((sum,s)=>sum + (parseFloat(s.ordinary)||0),0);
+      const growTotal = shareholders.reduce((sum,s)=>sum + (parseFloat(s.growth)||0),0);
+      const warning = document.getElementById('warning');
+      if (Math.abs(ordTotal-100) > 0.01 || Math.abs(growTotal-100) > 0.01){
+        warning.style.display = 'block';
+        warning.textContent = `Totals must equal 100%: Ordinary ${ordTotal.toFixed(2)}%, Growth ${growTotal.toFixed(2)}%`;
+        d3.select('#chart').html('');
+      } else {
+        warning.style.display = 'none';
+        renderChart();
+        renderTable();
+      }
+      updateURL();
     }
 
     function generateColors(){
@@ -234,15 +251,13 @@
       const newGrow = parseFloat(prompt('Growth % for '+s.name, s.growth));
       if(!isNaN(newGrow)) s.growth=newGrow;
       renderTable();
-      renderChart();
-      updateURL();
+      validateTotals();
     }
 
     document.getElementById('addShareholder').addEventListener('click',()=>{
       shareholders.push({name:'Shareholder'+(shareholders.length+1), ordinary:0, growth:0});
       renderTable();
-      renderChart();
-      updateURL();
+      validateTotals();
     });
 
     document.getElementById('shareTable').addEventListener('input',(e)=>{
@@ -251,8 +266,7 @@
       if(e.target.classList.contains('name')) shareholders[idx].name = e.target.value;
       if(e.target.classList.contains('ordinary')) shareholders[idx].ordinary = parseFloat(e.target.value)||0;
       if(e.target.classList.contains('growth')) shareholders[idx].growth = parseFloat(e.target.value)||0;
-      renderChart();
-      updateURL();
+      validateTotals();
     });
 
     document.getElementById('shareTable').addEventListener('click',(e)=>{
@@ -260,13 +274,12 @@
         const idx = e.target.getAttribute('data-idx');
         shareholders.splice(idx,1);
         renderTable();
-        renderChart();
-        updateURL();
+        validateTotals();
       }
     });
 
-    document.getElementById('threshold').addEventListener('input',()=>{renderChart(); updateURL();});
-    document.getElementById('maxValue').addEventListener('input',()=>{renderChart(); updateURL();});
+    document.getElementById('threshold').addEventListener('input',()=>{validateTotals();});
+    document.getElementById('maxValue').addEventListener('input',()=>{validateTotals();});
 
     document.getElementById('download').addEventListener('click',()=>{
       const svg = document.querySelector('#chart svg');
@@ -289,8 +302,7 @@
 
     loadFromURL();
     renderTable();
-    renderChart();
-    updateURL();
+    validateTotals();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add warning banner in Growth calculator when share percentages don't sum to 100%
- validate ordinary and growth totals before rendering table and chart
- block chart rendering until totals are corrected

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68c0aba621248324b2f07c53e34cff85