### PR TITLE
feat: dynamically orient growth chart labels

### DIFF
--- a/index/Growth.html
+++ b/index/Growth.html
@@ -198,9 +198,15 @@
         .attr('y',y(threshold)+ (y(0)-y(threshold))/2)
         .text(d=>`${d.s.name} (${d.s.ordinary}%)`)
         .each(function(d){
-          const widthRect = x(d.x+d.width)-x(d.x);
-          if(widthRect < 60) d3.select(this).classed('vertical',true);
-          if(widthRect < 20) d3.select(this).style('font-size','8px');
+          const rectWidth = x(d.x + d.width) - x(d.x);
+          const textSel = d3.select(this);
+          const textWidth = this.getBBox().width;
+          if (textWidth > rectWidth) {
+            textSel.classed('vertical', true);
+            const fontSize = parseFloat(textSel.style('font-size'));
+            const scale = rectWidth / textWidth;
+            textSel.style('font-size', (fontSize * scale) + 'px');
+          }
         });
 
       // labels growth
@@ -210,9 +216,15 @@
         .attr('y',y(maxVal)+ (y(threshold)-y(maxVal))/2)
         .text(d=>`${d.s.growth}%`)
         .each(function(d){
-          const widthRect = x(d.x+d.width)-x(d.x);
-          if(widthRect < 60) d3.select(this).classed('vertical',true);
-          if(widthRect < 20) d3.select(this).style('font-size','8px');
+          const rectWidth = x(d.x + d.width) - x(d.x);
+          const textSel = d3.select(this);
+          const textWidth = this.getBBox().width;
+          if (textWidth > rectWidth) {
+            textSel.classed('vertical', true);
+            const fontSize = parseFloat(textSel.style('font-size'));
+            const scale = rectWidth / textWidth;
+            textSel.style('font-size', (fontSize * scale) + 'px');
+          }
         });
     }
 


### PR DESCRIPTION
## Summary
- dynamically measure bar widths vs label text widths in Growth chart
- rotate and scale labels when text exceeds available bar width

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68c0abab136c8324be308aba5d1c2027