### PR TITLE
Fix color formatting for Growth chart

### DIFF
--- a/index/Growth.html
+++ b/index/Growth.html
@@ -139,9 +139,9 @@
         .range([d3.rgb('#a7c4f2'), d3.rgb('#4472C4')]);
       shareholders.forEach(s=>{
         if(s.ordinary>=5){
-          s.color = redScale(reds.indexOf(s)).formatHex();
+          s.color = d3.color(redScale(reds.indexOf(s))).formatHex();
         } else {
-          s.color = blueScale(blues.indexOf(s)).formatHex();
+          s.color = d3.color(blueScale(blues.indexOf(s))).formatHex();
         }
       });
     }


### PR DESCRIPTION
## Summary
- ensure Growth chart color strings are converted to D3 colors before formatting

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx -p puppeteer node - <<'NODE' ...` *(failed: package fetch 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68c0affd9f2c8324b2b5f8e472337075